### PR TITLE
feat: Print an immediate error if no input samples were found.

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,21 +1,14 @@
-# Main entrypoint of the workflow.
-# Please follow the best practices:
+# Main Snakefile and entry point of the workflow.
+# Please see the best practices:
 # https://snakemake.readthedocs.io/en/stable/snakefiles/best_practices.html,
 # in particular regarding the standardized folder structure mentioned there.
-
-
-# Main Snakefile
-
 
 # set config file where you can specify your inputs
 configfile: "config/config.yaml"
 
-
-# import glob to read {sample}
-import glob
-
 # set {samples} wildcard
-samples = glob_wildcards(config["hic_path"] + "{sample}_1.fastq.gz").sample
+samples_in_pattern = "{sample}_1.fastq.gz"
+samples = glob_wildcards(config["hic_path"] + samples_in_pattern).sample
 
 
 # Include the hifi_prep rule
@@ -58,4 +51,4 @@ include: "rules/common.smk"
 # input files are defined in the common.smk file
 rule all:
     input:
-        get_all_inputs(),
+        get_all_inputs

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,8 +1,14 @@
 # Define function for the inputs to rule_all
 # this rule just defines the inputs to the final rule
 
+def get_all_inputs(wc=None):
+    if not samples:
+        # Show the user a meaningful error message
+        logger.error(f"No files matching {samples_in_pattern} were found in"
+                     f" {config.get('hic_path')}. Please check your config file.")
+        logger.error(f"Exiting.")
+        sys.exit(1)
 
-def get_all_inputs():
     inputs = [
         "results/reads/hifi/hifi.fastq.gz",  # output of hifi_prep rule
         "results/nanoplot/NanoPlot-report.html",  # nanoplot report


### PR DESCRIPTION
Hi Lia,

I thought you might appreciate your first PR. It's a small one that just prints a nicer error if no samples are found:

```
snakemake) [tbooth2@sdf-cs1 colora]$ snakemake
Using profile conda_default for setting default command line arguments.
Multiple includes of /mnt/e1000/home/edg01/edg01/tbooth2/workspace/colora/workflow/rules/common.smk ignored
Multiple includes of /mnt/e1000/home/edg01/edg01/tbooth2/workspace/colora/workflow/rules/common.smk ignored
Multiple includes of /mnt/e1000/home/edg01/edg01/tbooth2/workspace/colora/workflow/rules/common.smk ignored
Multiple includes of /mnt/e1000/home/edg01/edg01/tbooth2/workspace/colora/workflow/rules/common.smk ignored
Multiple includes of /mnt/e1000/home/edg01/edg01/tbooth2/workspace/colora/workflow/rules/common.smk ignored
Multiple includes of /mnt/e1000/home/edg01/edg01/tbooth2/workspace/colora/workflow/rules/common.smk ignored
Building DAG of jobs...
No files matching {sample}_1.fastq.gz were found in resources/raw_hic/. Please check your config file.
Exiting.
```

I also cleaned up the top comment in the Snakefile and removed the unused glob import.

You can choose to accept this PR, or reject it, or ask me for modifications :-)